### PR TITLE
Add smooth movement animation for workers

### DIFF
--- a/scripts/Worker.gd
+++ b/scripts/Worker.gd
@@ -71,12 +71,20 @@ func can_move_to(target_position: Vector2i) -> bool:
 func move_to(target_position: Vector2i) -> bool:
 	if can_move_to(target_position):
 		grid_position = target_position
-		_update_position()
+		_animate_movement_to(target_position)
 		action_points -= 1
 		worker_moved.emit(self, target_position)
 		action_performed.emit(self, "move")
 		return true
 	return false
+
+func _animate_movement_to(target_grid_pos: Vector2i):
+	var target_world_pos = Vector2(target_grid_pos.x * TILE_SIZE + TILE_SIZE/2, target_grid_pos.y * TILE_SIZE + TILE_SIZE/2)
+	
+	var tween = create_tween()
+	tween.set_ease(Tween.EASE_OUT)
+	tween.set_trans(Tween.TRANS_CUBIC)
+	tween.tween_property(self, "position", target_world_pos, 0.3)
 
 func can_quarry() -> bool:
 	return action_points > 0 and carried_stones < max_stones


### PR DESCRIPTION
## Summary
- Replace instant worker teleportation with smooth sliding animation
- Add 0.3-second tween with EASE_OUT and TRANS_CUBIC for natural movement
- Workers now smoothly glide between tiles instead of jumping instantly

## Test plan
- [x] Select a worker and move to adjacent tiles
- [x] Verify smooth animation occurs during movement
- [x] Check that animation duration feels natural (not too fast/slow)
- [x] Ensure worker ends up at correct grid position after animation