### PR TITLE
Fix test_action_costs quarry action setup

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -310,8 +310,11 @@ func test_pathfinding_performance():
 
 ### Test Automation
 ```bash
-# Example CI command
-godot --headless --script addons/gut/gut_cmdln.gd -gtest_runner
+# Local development command (matches GitHub Actions)
+GODOT_SILENCE_ROOT_WARNING=1 godot --headless --path . -s addons/gut/gut_cmdln.gd -gdir=test -ginclude_subdirs -gexit
+
+# Alternative for specific test directories
+godot --headless -s addons/gut/gut_cmdln.gd -gdir=test/unit -gexit
 ```
 
 ### GitHub Actions Integration

--- a/test/unit/test_worker.gd
+++ b/test/unit/test_worker.gd
@@ -187,14 +187,15 @@ func test_action_costs(params=use_parameters([
 	var expected_cost = params[1]
 	
 	worker.action_points = 2
-	worker.carried_stones = 1  # Needed for place action
 	
 	match action:
 		"move":
 			worker.move_to(Vector2i(6, 5))
 		"quarry":
+			worker.carried_stones = 0  # Must have space to quarry
 			worker.quarry_stone()
 		"place":
+			worker.carried_stones = 1  # Must have stones to place
 			worker.place_stone()
 	
 	assert_eq(worker.action_points, 2 - expected_cost)


### PR DESCRIPTION
## Summary
- Fix failing unit test for quarry action cost validation
- Update testing documentation with correct commands from GitHub Actions

## Changes Made
- **test_worker.gd**: Set appropriate `carried_stones` values per action type
  - Quarry: `carried_stones=0` (workers need space to quarry stones)
  - Place: `carried_stones=1` (workers need stones to place)
- **testing.md**: Update test command to match GitHub Actions workflow

## Test Results
- ✅ All worker unit tests now pass (26/26)
- ✅ Quarry action correctly consumes 1 action point
- ✅ Test commands work consistently between local and CI

## Root Cause
The test was setting `carried_stones=1` globally, which prevented quarry actions since workers have `max_stones=1`. The `can_quarry()` method requires `carried_stones < max_stones`, so quarry attempts failed and didn't consume action points.