### PR TITLE
Fix Claude Code Review workflow authentication

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -72,10 +72,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
-          # Use repository dispatch event for PR context
-          github_event_name: ${{ github.event_name == 'repository_dispatch' && 'pull_request' || github.event_name }}
-          github_event_payload: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.pr_payload || '' }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           
           # Dynamic review prompt based on focus
           direct_prompt: |


### PR DESCRIPTION
## Summary
Fix authentication issues in Claude Code Review workflow

## Changes Made
- Remove invalid inputs: `github_event_name` and `github_event_payload`
- Add `github_token` parameter to use `GITHUB_TOKEN` for authentication

## Issue Fixed
The workflow was failing with:
- "Unexpected input(s) 'github_event_name', 'github_event_payload'" 
- "User does not have write access on this repository"

## Result
Claude Code Review action should now authenticate properly using `GITHUB_TOKEN`.