### PR TITLE
Fix end_turn function to properly end entire turn for all workers

### DIFF
--- a/scripts/GameManager.gd
+++ b/scripts/GameManager.gd
@@ -58,12 +58,8 @@ func _on_worker_action_performed(worker: WorkerClass, action: String):
 	if action == "place":
 		_check_pyramid_completion()
 
-func end_current_worker_turn():
-	var current_worker = get_current_worker()
-	if current_worker:
-		current_worker.action_points = 0
-	
-	_next_worker()
+func end_turn():
+	_start_new_turn()
 
 func _next_worker():
 	# Clear current selection

--- a/test/unit/test_game_manager.gd
+++ b/test/unit/test_game_manager.gd
@@ -66,13 +66,20 @@ func test_worker_selection_updates_current_index():
 	assert_eq(game_manager.current_worker_index, 1)
 	assert_eq(game_manager.get_current_worker(), mock_worker2)
 
-func test_end_current_worker_turn_sets_action_points_to_zero():
+func test_end_turn_resets_action_points_for_all_workers():
 	game_manager.add_worker(mock_worker1)
+	game_manager.add_worker(mock_worker2)
+	
 	mock_worker1.action_points = 2
+	mock_worker2.action_points = 1
 	
-	game_manager.end_current_worker_turn()
+	var initial_turn = game_manager.turn_number
 	
-	assert_eq(mock_worker1.action_points, 0)
+	game_manager.end_turn()
+	
+	assert_eq(game_manager.turn_number, initial_turn + 1)
+	assert_eq(mock_worker1.action_points, 2)
+	assert_eq(mock_worker2.action_points, 2)
 
 func test_next_worker_cycles_through_workers():
 	game_manager.add_worker(mock_worker1)


### PR DESCRIPTION
## Summary
Fix end_turn functionality following TDD approach - "End Turn" now properly ends entire turn for all workers instead of just current worker.

## Changes
- Replace `end_current_worker_turn()` with `end_turn()` function
- Update test to match correct behavior
- Simplified implementation: `end_turn()` calls `_start_new_turn()`

## Result
- ✅ All GameManager tests pass (20/20)
- ✅ Proper turn-based strategy game behavior